### PR TITLE
chore: Expose LDClient ahead of initial release

### DIFF
--- a/lib/ldclient-openfeature/provider.rb
+++ b/lib/ldclient-openfeature/provider.rb
@@ -8,6 +8,11 @@ module LaunchDarkly
     class Provider
       attr_reader :metadata
 
+      #
+      # @return client [LaunchDarkly::LDClient]
+      #
+      attr_reader :client
+
       NUMERIC_TYPES = %i[integer float number].freeze
       private_constant :NUMERIC_TYPES
 

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe LaunchDarkly::OpenFeature::Provider do
     expect(provider.metadata.name).to eq("launchdarkly-openfeature-server")
   end
 
+  it "exposes the underlying LaunchDarkly client" do
+    expect(provider.client).to be_a LaunchDarkly::LDClient
+  end
+
   it "not providing context returns error" do
     resolution_details = provider.fetch_boolean_value(flag_key: "flag-key", default_value: true)
 


### PR DESCRIPTION
Exposing the backing LDClient is useful for customers who want to use
OpenFeature where possible, but also want access to LaunchDarkly
specific functionality (e.g. migrations).
