### PR TITLE
ci: grant pull-requests:read so lint-pr-title workflow starts

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   lint-pr-title:
     uses: launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main


### PR DESCRIPTION
## Summary

Adds `permissions: pull-requests: read` at the workflow level in `.github/workflows/lint-pr-title.yml`.

The reusable workflow at `launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main` was updated (launchdarkly/gh-actions#86) to declare `permissions: pull-requests: read` at the job level. A reusable workflow can only request a subset of the permissions the caller grants, so without an explicit `permissions` block in the caller, every run hits `startup_failure`. Same fix as launchdarkly/sdk-meta#429.

## Review & Testing Checklist for Human

- [ ] Verify the `Lint PR title` workflow run on this PR exits `success` rather than `startup_failure`

### Notes

No product code is changed — workflow-only permissions fix being applied across SDK repos that use the reusable `lint-pr-title` workflow.

Link to Devin session: https://app.devin.ai/sessions/c7b96da5c9074500aa684bc9a9ba1c31
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts GitHub Actions workflow permissions and does not touch product code. The main impact is on CI behavior (enabling the reusable lint workflow to start successfully).
> 
> **Overview**
> Updates the `Lint PR title` GitHub Actions workflow to explicitly grant `pull-requests: read` permissions at the workflow level so the reusable `lint-pr-title` workflow can run without `startup_failure` on `pull_request_target` events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bae391d29f734e546062dbee787feaa36022910. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->