### PR TITLE
feat: Support OpenFeature tracking

### DIFF
--- a/launchdarkly-openfeature-server-sdk.gemspec
+++ b/launchdarkly-openfeature-server-sdk.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "launchdarkly-server-sdk", "~> 8.4"
-  spec.add_runtime_dependency "openfeature-sdk", ">= 0.6.1", "< 0.7.0"
+  spec.add_runtime_dependency "openfeature-sdk", "~> 0.6.1"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/launchdarkly-openfeature-server-sdk.gemspec
+++ b/launchdarkly-openfeature-server-sdk.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "launchdarkly-server-sdk", "~> 8.4"
-  spec.add_runtime_dependency "openfeature-sdk", "~> 0.6.0"
+  spec.add_runtime_dependency "openfeature-sdk", ">= 0.6.1", "< 0.7.0"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lib/ldclient-openfeature/provider.rb
+++ b/lib/ldclient-openfeature/provider.rb
@@ -33,6 +33,7 @@ module LaunchDarkly
       def initialize(sdk_key, config = LaunchDarkly::Config.default, wait_for_seconds = 5)
         @client = LaunchDarkly::LDClient.new(sdk_key, config, wait_for_seconds)
 
+        @logger = config.logger
         @context_converter = Impl::EvaluationContextConverter.new(config.logger)
         @details_converter = Impl::ResolutionDetailsConverter.new
 
@@ -61,6 +62,32 @@ module LaunchDarkly
 
       def fetch_object_value(flag_key:, default_value:, evaluation_context: nil)
         resolve_value(:object, flag_key, default_value, evaluation_context)
+      end
+
+      #
+      # Track a custom event, which can be used as a metric for an experiment.
+      #
+      # @param tracking_event_name [String]
+      # @param evaluation_context [::OpenFeature::SDK::EvaluationContext, nil]
+      # @param tracking_event_details [::OpenFeature::SDK::TrackingEventDetails, nil]
+      #
+      # @return [void]
+      #
+      def track(tracking_event_name, evaluation_context: nil, tracking_event_details: nil)
+        if evaluation_context.nil?
+          @logger.warn(
+            "The track method was called without an evaluation context. No event will be sent to LaunchDarkly, " \
+            "because a context is required to associate the event with."
+          )
+          return
+        end
+
+        ld_context = @context_converter.to_ld_context(evaluation_context)
+
+        data = tracking_event_details&.fields
+        data = nil if data.nil? || data.empty?
+
+        @client.track(tracking_event_name, ld_context, data, tracking_event_details&.value)
       end
 
       #

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -18,6 +18,31 @@ RSpec.describe LaunchDarkly::OpenFeature::Provider do
     expect(provider.client).to be_a LaunchDarkly::LDClient
   end
 
+  it "track sends a custom event for the provided context" do
+    allow(provider.client).to receive(:track)
+
+    provider.track("event-name", evaluation_context: evaluation_context)
+
+    expect(provider.client).to have_received(:track).with("event-name", instance_of(LaunchDarkly::LDContext), nil, nil)
+  end
+
+  it "track includes event details" do
+    details = OpenFeature::SDK::TrackingEventDetails.new(value: 3.14, category: "shopping")
+    allow(provider.client).to receive(:track)
+
+    provider.track("event-name", evaluation_context: evaluation_context, tracking_event_details: details)
+
+    expect(provider.client).to have_received(:track).with("event-name", instance_of(LaunchDarkly::LDContext), { "category" => "shopping" }, 3.14)
+  end
+
+  it "track without a context does not send an event" do
+    allow(provider.client).to receive(:track)
+
+    provider.track("event-name")
+
+    expect(provider.client).not_to have_received(:track)
+  end
+
   it "not providing context returns error" do
     resolution_details = provider.fetch_boolean_value(flag_key: "flag-key", default_value: true)
 


### PR DESCRIPTION
Implements the OpenFeature tracking API in the Ruby provider so experimentation metric events reach LaunchDarkly.

- Adds `Provider#track`, mapping `TrackingEventDetails#fields` to the LD custom event `data` and `#value` to `metric_value`.
- A `track` call without an evaluation context logs a warning and sends nothing, since LaunchDarkly requires a context to associate the event with.
- Raises the `openfeature-sdk` floor to `>= 0.6.1` (`< 0.7.0`); `TrackingEventDetails` and `Client#track` do not exist in 0.6.0.

<details>
<summary>Implementation details</summary>

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's pull request submission guidelines
- [x] I have validated my changes against all supported platform versions

**Related issues**

Part of an audit of the LaunchDarkly OpenFeature providers against the current OpenFeature specification. Tracking (spec section 6) was unimplemented here, and per spec 6.1.4 the OpenFeature SDK silently no-ops when a provider lacks `track`, so events were being dropped without any error.

**Describe the solution you've provided**

`OpenFeature::SDK::Client#track` forwards to `provider.track(name, evaluation_context:, tracking_event_details:)`. The provider converts the evaluation context with the existing `EvaluationContextConverter` and calls `LDClient#track(event_name, context, data, metric_value)`. Empty `fields` are normalized to `nil` so no empty hash is attached to the event.

**Describe alternatives you've considered**

Sending the event with an anonymous/placeholder context when no evaluation context is supplied — rejected, because it would attribute metric events to a context the application never used. Warning and dropping matches the behavior of the Python provider.

**Testing**

`bundle exec rake` (RSpec + RuboCop) on Ruby 3.4: 57 examples, 0 failures; 12 files inspected, no offenses. Ruby 3.4 was used because the gemspec requires `>= 3.4`.

</details>

@cursor review


Link to Devin session: https://app.devin.ai/sessions/0c452d209ec54b068ba120b4c92b8f6c
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Implements OpenFeature **tracking** on the Ruby provider so experiment metric events reach LaunchDarkly instead of being silently dropped.
> 
> `Provider#track` converts the evaluation context and maps `TrackingEventDetails#fields` to LD event `data` and `#value` to `metric_value`. Calls without a context log a warning and send nothing (LD requires a context). Empty `fields` are sent as `nil`.
> 
> Bumps `openfeature-sdk` from `~> 0.6.0` to `~> 0.6.1` because tracking types/APIs are not in 0.6.0. Specs cover context, details, and the no-context no-op.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd471eaabfc935b8e88bf2aff7316969cb1b6cf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->