### PR TITLE
feat: Support provider initialization and shutdown

### DIFF
--- a/lib/ldclient-openfeature/provider.rb
+++ b/lib/ldclient-openfeature/provider.rb
@@ -40,6 +40,31 @@ module LaunchDarkly
         @metadata = ::OpenFeature::SDK::Provider::ProviderMetadata.new(name: "launchdarkly-openfeature-server").freeze
       end
 
+      #
+      # Called by the OpenFeature SDK when this provider is set. The LaunchDarkly client has already been given the
+      # opportunity to initialize, so this only reports whether that succeeded.
+      #
+      # @param _evaluation_context [::OpenFeature::SDK::EvaluationContext, nil]
+      #
+      # @return [void]
+      #
+      def init(_evaluation_context = nil)
+        return if @client.initialized?
+
+        state = @client.data_source_status_provider.status.state
+        raise "the LaunchDarkly client was unable to initialize; the data source state is #{state}"
+      end
+
+      #
+      # Called by the OpenFeature SDK when this provider is replaced or the SDK is shut down. The LaunchDarkly client
+      # cannot be restarted, so a new provider instance is required afterward.
+      #
+      # @return [void]
+      #
+      def shutdown
+        @client.close
+      end
+
       def fetch_boolean_value(flag_key:, default_value:, evaluation_context: nil)
         resolve_value(:boolean, flag_key, default_value, evaluation_context)
       end

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -43,6 +43,26 @@ RSpec.describe LaunchDarkly::OpenFeature::Provider do
     expect(provider.client).not_to have_received(:track)
   end
 
+  it "init succeeds when the client is initialized" do
+    expect { provider.init(evaluation_context) }.not_to raise_error
+  end
+
+  it "init raises when the client failed to initialize" do
+    status = LaunchDarkly::Interfaces::DataSource::Status.new(LaunchDarkly::Interfaces::DataSource::Status::OFF, Time.now, nil)
+    status_provider = double(status: status)
+    allow(provider.client).to receive_messages(initialized?: false, data_source_status_provider: status_provider)
+
+    expect { provider.init(evaluation_context) }.to raise_error(/unable to initialize/)
+  end
+
+  it "shutdown closes the client" do
+    allow(provider.client).to receive(:close)
+
+    provider.shutdown
+
+    expect(provider.client).to have_received(:close)
+  end
+
   it "not providing context returns error" do
     resolution_details = provider.fetch_boolean_value(flag_key: "flag-key", default_value: true)
 


### PR DESCRIPTION
Implements the OpenFeature provider lifecycle hooks so the OpenFeature SDK can reflect LaunchDarkly initialization failures and release resources.

- Adds `Provider#init`, which raises when the LaunchDarkly client did not initialize, so the OpenFeature SDK moves the provider to `ERROR` instead of reporting `READY`.
- Adds `Provider#shutdown`, which closes the LaunchDarkly client when the provider is replaced or `OpenFeature::SDK.shutdown` is called.
- The LaunchDarkly client is still created in the constructor, matching the Java provider; a client cannot be restarted, so a new provider instance is required after shutdown.

<details>
<summary>Implementation details</summary>

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's pull request submission guidelines
- [x] I have validated my changes against all supported platform versions

**Related issues**

Part of an audit of the LaunchDarkly OpenFeature providers against the current OpenFeature specification. Provider lifecycle (spec sections 2.4 / 1.7) was unimplemented here: initialization failures were invisible to the OpenFeature SDK, and shutting down the OpenFeature SDK leaked the LaunchDarkly client's connections and event processor.

**Describe the solution you've provided**

`OpenFeature::SDK::Configuration` calls `init` on providers that respond to it and dispatches `PROVIDER_READY` on success, or `PROVIDER_ERROR` when `init` raises; it calls `shutdown` on providers that respond to it. `init` uses `LDClient#initialized?` and includes the data source state from `data_source_status_provider` in the raised error message for diagnosability.

**Describe alternatives you've considered**

Deferring LaunchDarkly client construction to `init` — rejected because it would change the meaning of the existing public `client` accessor and the constructor's `wait_for_seconds` argument. Blocking inside `init` on a data source status listener — rejected as redundant, since the constructor already waits, and later state changes are better delivered as provider events.

**Testing**

`bundle exec rake` (RSpec + RuboCop) on Ruby 3.4: 57 examples, 0 failures; 12 files inspected, no offenses. Ruby 3.4 was used because the gemspec requires `>= 3.4`.

</details>

@cursor review


Link to Devin session: https://app.devin.ai/sessions/0c452d209ec54b068ba120b4c92b8f6c
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Implements OpenFeature provider lifecycle so the SDK can report LaunchDarkly init failures and release resources.
> 
> `Provider#init` no-ops if the client is already initialized; otherwise it raises with the data source state so OpenFeature can move the provider to ERROR instead of READY. `Provider#shutdown` closes the LaunchDarkly client. Construction still happens in the constructor; a closed client cannot be restarted.
> 
> Specs cover successful init, failed init, and shutdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc88a8b8dace30a55c23d73d1e81516814c2f074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->