### PR TITLE
feat: Emit provider events from LaunchDarkly client status

### DIFF
--- a/lib/ldclient-openfeature.rb
+++ b/lib/ldclient-openfeature.rb
@@ -2,6 +2,7 @@
 
 require_relative "ldclient-openfeature/impl/context_converter"
 require_relative "ldclient-openfeature/impl/details_converter"
+require_relative "ldclient-openfeature/impl/event_listeners"
 require_relative "ldclient-openfeature/provider"
 require_relative "ldclient-openfeature/version"
 

--- a/lib/ldclient-openfeature/impl/event_listeners.rb
+++ b/lib/ldclient-openfeature/impl/event_listeners.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'ldclient-rb'
+require 'open_feature/sdk'
+
+module LaunchDarkly
+  module OpenFeature
+    module Impl
+      #
+      # Translates LaunchDarkly data source status changes into OpenFeature provider events.
+      #
+      class DataSourceStatusListener
+        #
+        # @param provider [LaunchDarkly::OpenFeature::Provider]
+        #
+        def initialize(provider)
+          @provider = provider
+        end
+
+        #
+        # @param status [LaunchDarkly::Interfaces::DataSource::Status]
+        #
+        # @return [void]
+        #
+        def update(status)
+          case status.state
+          when ::LaunchDarkly::Interfaces::DataSource::Status::VALID
+            @provider.emit_event(::OpenFeature::SDK::ProviderEvent::PROVIDER_READY)
+          when ::LaunchDarkly::Interfaces::DataSource::Status::INTERRUPTED
+            @provider.emit_event(
+              ::OpenFeature::SDK::ProviderEvent::PROVIDER_STALE,
+              message: message(status, "the data source has been interrupted")
+            )
+          when ::LaunchDarkly::Interfaces::DataSource::Status::OFF
+            @provider.emit_event(
+              ::OpenFeature::SDK::ProviderEvent::PROVIDER_ERROR,
+              error_code: ::OpenFeature::SDK::Provider::ErrorCode::GENERAL,
+              message: message(status, "the data source has been permanently shut down")
+            )
+          end
+        end
+
+        #
+        # @param status [LaunchDarkly::Interfaces::DataSource::Status]
+        # @param fallback [String]
+        #
+        # @return [String]
+        #
+        private def message(status, fallback)
+          error = status.last_error
+          return fallback if error.nil?
+
+          "#{fallback}: #{error.kind} #{error.status_code} #{error.message}".strip
+        end
+      end
+
+      #
+      # Translates LaunchDarkly flag change events into OpenFeature configuration changed events.
+      #
+      class FlagChangeListener
+        #
+        # @param provider [LaunchDarkly::OpenFeature::Provider]
+        #
+        def initialize(provider)
+          @provider = provider
+        end
+
+        #
+        # @param flag_change [LaunchDarkly::Interfaces::FlagChange]
+        #
+        # @return [void]
+        #
+        def update(flag_change)
+          @provider.emit_event(
+            ::OpenFeature::SDK::ProviderEvent::PROVIDER_CONFIGURATION_CHANGED,
+            flags_changed: [flag_change.key]
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/ldclient-openfeature/provider.rb
+++ b/lib/ldclient-openfeature/provider.rb
@@ -6,6 +6,8 @@ require 'open_feature/sdk'
 module LaunchDarkly
   module OpenFeature
     class Provider
+      include ::OpenFeature::SDK::Provider::EventEmitter
+
       #
       # Retrieve metadata information describing this provider.
       #
@@ -37,6 +39,9 @@ module LaunchDarkly
         @details_converter = Impl::ResolutionDetailsConverter.new
 
         @metadata = ::OpenFeature::SDK::Provider::ProviderMetadata.new(name: "launchdarkly-openfeature-server").freeze
+
+        @client.data_source_status_provider.add_listener(Impl::DataSourceStatusListener.new(self))
+        @client.flag_tracker.add_listener(Impl::FlagChangeListener.new(self))
       end
 
       def fetch_boolean_value(flag_key:, default_value:, evaluation_context: nil)

--- a/spec/impl/data_source_status_listener_spec.rb
+++ b/spec/impl/data_source_status_listener_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe LaunchDarkly::OpenFeature::Impl::DataSourceStatusListener do
+  let(:provider) { double(emit_event: nil) }
+  let(:listener) { described_class.new(provider) }
+
+  def status(state, error = nil)
+    LaunchDarkly::Interfaces::DataSource::Status.new(state, Time.now, error)
+  end
+
+  it "a valid data source is ready" do
+    listener.update(status(LaunchDarkly::Interfaces::DataSource::Status::VALID))
+
+    expect(provider).to have_received(:emit_event).with(OpenFeature::SDK::ProviderEvent::PROVIDER_READY)
+  end
+
+  it "an interrupted data source is stale" do
+    listener.update(status(LaunchDarkly::Interfaces::DataSource::Status::INTERRUPTED))
+
+    expect(provider).to have_received(:emit_event)
+      .with(OpenFeature::SDK::ProviderEvent::PROVIDER_STALE, hash_including(:message))
+  end
+
+  it "a shut down data source is an error" do
+    error = LaunchDarkly::Interfaces::DataSource::ErrorInfo.new(
+      LaunchDarkly::Interfaces::DataSource::ErrorInfo::ERROR_RESPONSE, 401, "Unauthorized", Time.now
+    )
+
+    listener.update(status(LaunchDarkly::Interfaces::DataSource::Status::OFF, error))
+
+    expect(provider).to have_received(:emit_event).with(
+      OpenFeature::SDK::ProviderEvent::PROVIDER_ERROR,
+      hash_including(error_code: OpenFeature::SDK::Provider::ErrorCode::GENERAL, message: /401/)
+    )
+  end
+
+  it "an initializing data source does not emit an event" do
+    listener.update(status(LaunchDarkly::Interfaces::DataSource::Status::INITIALIZING))
+
+    expect(provider).not_to have_received(:emit_event)
+  end
+end

--- a/spec/impl/flag_change_listener_spec.rb
+++ b/spec/impl/flag_change_listener_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe LaunchDarkly::OpenFeature::Impl::FlagChangeListener do
+  let(:provider) { double(emit_event: nil) }
+
+  it "a flag change is a configuration change" do
+    described_class.new(provider).update(LaunchDarkly::Interfaces::FlagChange.new("flag-key"))
+
+    expect(provider).to have_received(:emit_event).with(
+      OpenFeature::SDK::ProviderEvent::PROVIDER_CONFIGURATION_CHANGED,
+      flags_changed: ["flag-key"]
+    )
+  end
+end


### PR DESCRIPTION
Forwards LaunchDarkly client status and flag change notifications to the OpenFeature SDK as provider events.

- The provider now includes `OpenFeature::SDK::Provider::EventEmitter` and registers listeners on the LaunchDarkly data source status provider and flag tracker.
- `VALID` emits `PROVIDER_READY`, `INTERRUPTED` emits `PROVIDER_STALE`, and `OFF` emits `PROVIDER_ERROR` with the `GENERAL` error code and the last error in the message.
- `OFF` deliberately does not use `PROVIDER_FATAL`: the LaunchDarkly client can still evaluate its last known flag data, and a fatal state would make the OpenFeature SDK return call-site defaults instead.
- Flag changes emit `PROVIDER_CONFIGURATION_CHANGED` with the changed flag key.

<details>
<summary>Implementation details</summary>

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's pull request submission guidelines
- [x] I have validated my changes against all supported platform versions

**Related issues**

Part of an audit of the LaunchDarkly OpenFeature providers against the current OpenFeature specification. Provider events (spec section 5) were not implemented here, so applications had no way to react to LaunchDarkly connection loss, recovery, or flag configuration changes through the OpenFeature API.

**Describe the solution you've provided**

Two small listener classes in `Impl` translate LaunchDarkly notifications into OpenFeature events, and the provider registers them when the client is constructed. `EventEmitter#emit_event` is a no-op until the OpenFeature SDK attaches its configuration to the provider, so events raised before the provider is set are safely dropped.

**Describe alternatives you've considered**

Mapping `OFF` to `PROVIDER_FATAL` — rejected for the reason above; this matches the Java provider and the corresponding fix being made in the Python provider. Emitting one event per changed flag with no payload — rejected in favor of including `flags_changed` so handlers can filter.

**Testing**

`bundle exec rake` (RSpec + RuboCop) on Ruby 3.4: 59 examples, 0 failures; 15 files inspected, no offenses. Ruby 3.4 was used because the gemspec requires `>= 3.4`.

</details>

@cursor review


Link to Devin session: https://app.devin.ai/sessions/0c452d209ec54b068ba120b4c92b8f6c
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Implements **OpenFeature provider events** (spec section 5) so apps can react to LaunchDarkly connection state and flag updates through the OpenFeature API.
> 
> The **Provider** now includes `OpenFeature::SDK::Provider::EventEmitter` and registers two listeners when the LD client is constructed: on `data_source_status_provider` and `flag_tracker`.
> 
> **Data source status** maps to events: `VALID` → `PROVIDER_READY`, `INTERRUPTED` → `PROVIDER_STALE` (with message), `OFF` → `PROVIDER_ERROR` with `GENERAL` and last error details in the message—not `PROVIDER_FATAL`, so evaluation can still use last-known flags. `INITIALIZING` emits nothing.
> 
> **Flag changes** emit `PROVIDER_CONFIGURATION_CHANGED` with `flags_changed` containing the changed key.
> 
> New `Impl::DataSourceStatusListener` and `Impl::FlagChangeListener` translate LD notifications into `emit_event` calls; specs cover each mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc2ae67688a3150675e3b09a6254161804f3bd01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->