### PR TITLE
feat: Report provider name and version to LaunchDarkly

### DIFF
--- a/launchdarkly-openfeature-server-sdk.gemspec
+++ b/launchdarkly-openfeature-server-sdk.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "launchdarkly-server-sdk", "~> 8.4"
+  spec.add_runtime_dependency "launchdarkly-server-sdk", ">= 8.15.0", "< 9.0"
   spec.add_runtime_dependency "openfeature-sdk", "~> 0.6.1"
 
   # For more information and examples about making a new gem, check out our

--- a/launchdarkly-openfeature-server-sdk.gemspec
+++ b/launchdarkly-openfeature-server-sdk.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "launchdarkly-server-sdk", ">= 8.15.0", "< 9.0"
+  spec.add_runtime_dependency "launchdarkly-server-sdk", "~> 8.15"
   spec.add_runtime_dependency "openfeature-sdk", "~> 0.6.1"
 
   # For more information and examples about making a new gem, check out our

--- a/lib/ldclient-openfeature/provider.rb
+++ b/lib/ldclient-openfeature/provider.rb
@@ -27,13 +27,16 @@ module LaunchDarkly
       NUMERIC_TYPES = %i[integer float number].freeze
       private_constant :NUMERIC_TYPES
 
+      WRAPPER_NAME = "open-feature-ruby-server"
+      private_constant :WRAPPER_NAME
+
       #
       # @param sdk_key [String]
       # @param config [LaunchDarkly::Config]
       # @param wait_for_seconds [Float]
       #
       def initialize(sdk_key, config = LaunchDarkly::Config.default, wait_for_seconds = 5)
-        @client = LaunchDarkly::LDClient.new(sdk_key, config, wait_for_seconds)
+        @client = LaunchDarkly::LDClient.new(sdk_key, config.with_wrapper_information(WRAPPER_NAME, VERSION), wait_for_seconds)
 
         @logger = config.logger
         @context_converter = Impl::EvaluationContextConverter.new(config.logger)

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -63,6 +63,19 @@ RSpec.describe LaunchDarkly::OpenFeature::Provider do
     expect(provider.client).to have_received(:close)
   end
 
+  it "reports itself as the wrapper to LaunchDarkly" do
+    allow(LaunchDarkly::LDClient).to receive(:new).and_return(instance_double(LaunchDarkly::LDClient))
+
+    described_class.new("example-key", config)
+
+    expect(LaunchDarkly::LDClient).to have_received(:new).with(
+      "example-key",
+      having_attributes(wrapper_name: "open-feature-ruby-server", wrapper_version: LaunchDarkly::OpenFeature::VERSION),
+      5
+    )
+    expect(config.wrapper_name).to be_nil
+  end
+
   it "not providing context returns error" do
     resolution_details = provider.fetch_boolean_value(flag_key: "flag-key", default_value: true)
 

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -64,7 +64,12 @@ RSpec.describe LaunchDarkly::OpenFeature::Provider do
   end
 
   it "reports itself as the wrapper to LaunchDarkly" do
-    allow(LaunchDarkly::LDClient).to receive(:new).and_return(instance_double(LaunchDarkly::LDClient))
+    client = instance_double(
+      LaunchDarkly::LDClient,
+      data_source_status_provider: double(add_listener: nil),
+      flag_tracker: double(add_listener: nil)
+    )
+    allow(LaunchDarkly::LDClient).to receive(:new).and_return(client)
 
     described_class.new("example-key", config)
 


### PR DESCRIPTION
Reports the provider as the wrapper so LaunchDarkly can attribute usage to the OpenFeature Ruby provider rather than the base Ruby SDK.

- The provider derives its client configuration with `Config#with_wrapper_information("open-feature-ruby-server", VERSION)`, leaving the application's configuration untouched.
- Requires `launchdarkly-server-sdk ~> 8.15`, the release that adds `Config#with_wrapper_information` (launchdarkly/ruby-server-sdk#421). That version is now published, so dependency resolution succeeds.

<details>
<summary>Implementation details</summary>

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's pull request submission guidelines
- [x] I have validated my changes against all supported platform versions

**Related issues**

Part of an audit of the LaunchDarkly OpenFeature providers against the current OpenFeature specification. The Java and .NET providers already identify themselves via wrapper info; the Ruby provider did not, so usage of this provider was indistinguishable from direct use of the Ruby server SDK.

**Describe the solution you've provided**

`Config` exposes `wrapper_name`/`wrapper_version` as readers only, so the base SDK gained a supported way to derive a configuration with different wrapper information. The provider calls it when constructing its client.

**Describe alternatives you've considered**

Setting the configuration's instance variables from the provider — rejected, as the provider must not depend on SDK internals. Rebuilding the configuration from its public readers — rejected because it would silently drop configuration options the provider does not know about.

**Testing**

`bundle exec rake` (RSpec + RuboCop) on Ruby 3.4: 55 examples, 0 failures; 12 files inspected, no offenses. CI now resolves against the published 8.15.0 gem.

</details>


Link to Devin session: https://app.devin.ai/sessions/0c452d209ec54b068ba120b4c92b8f6c
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> The OpenFeature Ruby provider now identifies itself to LaunchDarkly as wrapper `open-feature-ruby-server` with the gem `VERSION`, so usage is attributed to this provider instead of the base Ruby SDK.
> 
> On client construction it derives config via `Config#with_wrapper_information` and leaves the caller’s `Config` unchanged. Runtime dependency is bumped to `launchdarkly-server-sdk ~> 8.15` for that API. A spec asserts wrapper name/version are passed through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffac4cfd24c2d759b64ca73da078a9d511496c1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->