### PR TITLE
ci: Run RuboCop serially to avoid JRuby thread-parallel failures

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -22,4 +22,4 @@ runs:
 
     - name: Run RuboCop
       shell: bash
-      run: bundle exec rubocop --parallel
+      run: bundle exec rubocop


### PR DESCRIPTION
Run RuboCop serially, because `--parallel` is broken under JRuby as of RuboCop 1.90.0.

- CI's `build-linux (jruby-10.0)` job started failing on `main` with no code change, purely from RuboCop floating from 1.89.0 to 1.90.0 (released 2026-08-24)
- Parallelism buys nothing here: the repo has 15 files to inspect
- No behavior change for the CRuby/Windows jobs beyond losing the (negligible) parallel speedup

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Failing run: https://github.com/launchdarkly/openfeature-ruby-server/actions/runs/32897505749/job/97963432418

<details>
<summary>Implementation details</summary>

**Root cause**

The failing step emitted 1315 internal cop errors ("An error occurred while `Layout/SpaceBeforeFirstArg` cop was inspecting ...") plus 12 phantom offenses whose reported line/column did not match the source line printed alongside them (e.g. `Layout/DefEndAlignment` pointing at a comment). The offenses are not real; the AST node locations are wrong.

On JRuby, the `parallel` gem cannot fork, so `Parallel.each` takes its `RUBY_PLATFORM.include?('java')` branch and runs work in threads rather than worker processes. RuboCop 1.90 began preserving cop instances across files (rubocop/rubocop#11119), and `RuboCop::Cop::Base` documents the assumption that "under `--parallel` each worker process has its own cop instances, so state persists only within a worker's share of the files". Under threads that assumption does not hold: the reused cop instances see concurrent `processed_source` values, which is consistent with the mismatched locations. The thread/instance-sharing mechanism is a reading of the RuboCop source, not an upstream-confirmed diagnosis.

**Verification (local, Java 21)**

| JRuby | RuboCop | `--parallel` | serial |
| --- | --- | --- | --- |
| 10.0.4.0 | 1.90.0 | fails | clean |
| 10.0.6.0 | 1.90.0 | fails | clean |
| 10.1.1.0 | 1.90.0 | fails | clean |
| 10.0.4.0 | 1.89.0 | clean | clean |

So no JRuby upgrade avoids this, and pinning RuboCop would only defer it.

**Alternatives considered**

- Pin `rubocop` to `~> 1.89.0` in the Gemfile: hides the problem and freezes lint at an old version.
- Skip the RuboCop step entirely on JRuby: also works (the CRuby job covers lint), but drops JRuby-specific coverage for no benefit over running serially.
- Set `AllCops: ParserEngine: parser_whitequark`: not validated, and does not address the thread-safety issue.

</details>


Link to Devin session: https://app.devin.ai/sessions/47847578334a4bd497c24e3859630cd2
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> CI’s shared RuboCop step no longer passes **`--parallel`**, so lint runs serially on every Ruby platform.
> 
> That sidesteps RuboCop 1.90’s broken parallel path on JRuby (threads reuse cop instances and produce bogus offenses). With only ~15 files, the parallel speedup was negligible anyway.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae9f49b0553811d3960103538da0a04c9ef050ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->